### PR TITLE
Update composer.json - support PHP 8.1 and Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.3|^8.0|^8.1",
         "ext-json": "*",
         "spatie/geocoder": "^3.1",
-        "laravel/framework": "^7.0|^8.0|^9.0|10.0"
+        "laravel/framework": "^7.0|^8.0|^9.0|^10.31"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.3|^8.0|^8.1",
         "ext-json": "*",
         "spatie/geocoder": "^3.1",
-        "laravel/framework": "^7.0|^8.0|^9.0"
+        "laravel/framework": "^7.0|^8.0|^9.0|10.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^5.0",


### PR DESCRIPTION
To support Laravel 10.x which required PHP 8.1.
This package is required in our app. Since we are upgrading the laravel version to 10.x, we need to upgrade this package to support Laravel 10.x. hence sending the PR.

Link Issue: https://github.com/americandiscount/adc-api/issues/613